### PR TITLE
Update TotK Config Path

### DIFF
--- a/TKMM.SarcTool.Core/GdlPackager.cs
+++ b/TKMM.SarcTool.Core/GdlPackager.cs
@@ -26,7 +26,7 @@ public class GdlPackager {
     public GdlPackager(string? configPath = null) {
         configPath ??= Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Totk", "config.json");
+            "totk", "Config.json");
 
         if (!File.Exists(configPath))
             throw new Exception($"{configPath} not found");

--- a/TKMM.SarcTool.Core/SarcAssembler.cs
+++ b/TKMM.SarcTool.Core/SarcAssembler.cs
@@ -42,7 +42,7 @@ public class SarcAssembler {
         
         configPath ??= Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Totk", "config.json");
+            "totk", "Config.json");
 
         if (!File.Exists(configPath))
             throw new Exception($"{configPath} not found");

--- a/TKMM.SarcTool.Core/SarcMerger.cs
+++ b/TKMM.SarcTool.Core/SarcMerger.cs
@@ -69,7 +69,7 @@ public class SarcMerger {
         
         configPath ??= Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Totk", "config.json");
+            "totk", "Config.json");
 
         shopsPath ??= Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "tkmm",
                                      "shops.json");

--- a/TKMM.SarcTool.Core/SarcPackager.cs
+++ b/TKMM.SarcTool.Core/SarcPackager.cs
@@ -69,7 +69,7 @@ public class SarcPackager {
         
         configPath ??= Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "Totk", "config.json");
+            "totk", "Config.json");
         
         checksumPath ??= Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                                       "Totk", "checksums.bin");


### PR DESCRIPTION
Uses the expected `totk/Config.json` path instead of `Totk/config.json` for proper linux compatibility.

Fixes https://github.com/TKMM-Team/Tkmm/issues/17