### PR TITLE
Correctly Name versioned Archive and Flat BYML files

### DIFF
--- a/TKMM.SarcTool.Core/TKMM.SarcTool.Core.csproj
+++ b/TKMM.SarcTool.Core/TKMM.SarcTool.Core.csproj
@@ -11,9 +11,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Tkmm.BymlLibrary" Version="1.0.9" />
+        <PackageReference Include="Tkmm.BymlLibrary" Version="1.0.11" />
         <PackageReference Include="SarcLibrary" Version="3.1.3" />
-        <PackageReference Include="TotkCommon" Version="1.2.4" />
+        <PackageReference Include="TotkCommon" Version="1.2.9" />
         <PackageReference Include="ZstdSharp.Port" Version="0.8.1" />
     </ItemGroup>
 


### PR DESCRIPTION
This is a fix for https://github.com/TKMM-Team/Tkmm/issues/39.

Files with a version string are written as they are in the changelog, which is sometimes wrong depending on the game version the mod is built on.

This PR uses the AddressTable file in `System/AddressTable` to get the correct file name for these files.